### PR TITLE
Incoming video stream decompression

### DIFF
--- a/camera_controls/launch/cam.launch
+++ b/camera_controls/launch/cam.launch
@@ -2,4 +2,20 @@
 	<node name="udp_receiver" pkg="nimbro_topic_transport" type="udp_receiver" output="screen">
 		<param name="port" value="17001" />
 	</node>
+
+	<node
+		name="camera_1_decompressor"
+		pkg="image_transport"
+		type="republish"
+		args="compressed in:=/camera_1/image_raw raw out:=/camera_1/decompressed"
+		output="screen"
+	/>
+
+	<node
+		name="camera_2_decompressor"
+		pkg="image_transport"
+		type="republish"
+		args="compressed in:=/camera_2/image_raw raw out:=/camera_2/decompressed"
+		output="screen"
+	/>
 </launch>

--- a/camera_controls/launch/cam.launch
+++ b/camera_controls/launch/cam.launch
@@ -1,5 +1,9 @@
 <launch>
 	<node name="udp_receiver" pkg="nimbro_topic_transport" type="udp_receiver" output="screen">
 		<param name="port" value="17001" />
+
+		<!-- The below is temporary, for local testing. -->
+		<remap from="/camera_1/image_raw/compressed" to="/recv/camera_1/image_raw/compressed" />
+		<remap from="/camera_2/image_raw/compressed" to="/recv/camera_2/image_raw/compressed" />
 	</node>
 </launch>

--- a/camera_controls/launch/cam.launch
+++ b/camera_controls/launch/cam.launch
@@ -1,9 +1,5 @@
 <launch>
 	<node name="udp_receiver" pkg="nimbro_topic_transport" type="udp_receiver" output="screen">
 		<param name="port" value="17001" />
-
-		<!-- The below is temporary, for local testing. -->
-		<remap from="/camera_1/image_raw/compressed" to="/recv/camera_1/image_raw/compressed" />
-		<remap from="/camera_2/image_raw/compressed" to="/recv/camera_2/image_raw/compressed" />
 	</node>
 </launch>


### PR DESCRIPTION
Decompresses incoming h264-encoded video streams. Viewing of the streams is currently done with `rqt_image_view`, but we can easily make our own interface later if required. To be merged in tandem with UofA-SPEAR/rover2#6.